### PR TITLE
Allow a "finished" task to be re-started

### DIFF
--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -885,12 +885,18 @@ OrderedTask::ReplaceOptionalStart(const OrderedTaskPoint &new_tp,
 void
 OrderedTask::SetActiveTaskPoint(unsigned index)
 {
-  if (index >= task_points.size() || index == active_task_point)
+  if (index > task_points.size() || index == active_task_point)
     return;
 
-  task_advance.SetArmed(false);
-  active_task_point = index;
-  force_full_update = true;
+  if (index == task_points.size()) {
+    // Special case - setting the index past the finish point "wraps" the
+    // task back to the beginning
+    Reset();
+  } else {
+    task_advance.SetArmed(false);
+    active_task_point = index;
+    force_full_update = true;
+  }
 }
 
 TaskWaypoint*

--- a/src/Engine/Task/Ordered/OrderedTask.hpp
+++ b/src/Engine/Task/Ordered/OrderedTask.hpp
@@ -654,6 +654,10 @@ public:
     name.clear();
   }
 
+  bool TaskFinished() const {
+    return stats.task_finished;
+  }
+
 public:
   /* virtual methods from class TaskInterface */
   unsigned TaskSize() const override {


### PR DESCRIPTION
Currently once a task has been finished there is no way of resetting the task
without exiting and re-starting XCSoar. Flying multiple laps of a small
task is common for racing practice/tutition - re-starting XCSoar on
each lap is a nuisance.